### PR TITLE
#11 Docker Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ See our [application server tutorials](https://support.idrsolutions.com/hc/en-us
 
 Tutorials for cloud platforms coming soon... 
 
+### docker-compose deployment: ###
+
+```
+docker-compose up
+```
+
+Visiting `localhost:8080` will bring you to the Tomcat page. 
+Click "Manager App" and log in with the following credentials: User - admin, Password - admin123.
+These credentials can be changed in ./lib/tomcat-users.xml in this repository prior to starting the container.
+
+In the list of applications, you will see the "/microservice-example" row at the bottom. In the "Commands" column, click "Start" if it is not already selected.
+
+Upon first conversion, the output may not be visible. To fix this, stop the container and restart it again using `docker-compose up` as described previously.
+
 -----
 
 ### Usage: ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+ 
+version: '2'
+services:
+  convert:
+    image: tomcat
+    ports: 
+      - "8080:8080"
+    volumes:
+      - ./lib/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
+      - ./lib/manager.xml:/usr/local/tomcat/conf/Catalina/localhost/manager.xml
+      - ./lib/docroot:/usr/local/tomcat/docroot
+      - ./target/microservice-example.war:/usr/local/tomcat/webapps/microservice-example.war
+      - ./target/microservice-example:/usr/local/tomcat/webapps/microservice-example

--- a/lib/manager.xml
+++ b/lib/manager.xml
@@ -1,0 +1,4 @@
+<Context privileged="true" antiResourceLocking="false" 
+         docBase="${catalina.home}/webapps/manager">
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve" allow="^.*$" />
+</Context>

--- a/lib/tomcat-users.xml
+++ b/lib/tomcat-users.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<!--
+  NOTE:  By default, no user is included in the "manager-gui" role required
+  to operate the "/manager/html" web application.  If you wish to use this app,
+  you must define such a user - the username and password are arbitrary. It is
+  strongly recommended that you do NOT use one of the users in the commented out
+  section below since they are intended for use with the examples web
+  application.
+-->
+<!--
+  NOTE:  The sample user and role entries below are intended for use with the
+  examples web application. They are wrapped in a comment and thus are ignored
+  when reading this file. If you wish to configure these users for use with the
+  examples web application, do not forget to remove the <!.. ..> that surrounds
+  them. You will also need to set the passwords to something appropriate.
+-->
+<!--
+  <role rolename="tomcat"/>
+  <role rolename="role1"/>
+  <user username="tomcat" password="<must-be-changed>" roles="tomcat"/>
+  <user username="both" password="<must-be-changed>" roles="tomcat,role1"/>
+  <user username="role1" password="<must-be-changed>" roles="role1"/>
+-->
+	<role rolename="manager-gui"/>
+	<user username="admin" password="admin123" roles="manager-gui"/>
+</tomcat-users>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     </dependencies>
     
     <build>
+        <finalName>microservice-example</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -19,6 +19,6 @@
 -->
 <Context>
     <Resources>
-        <PreResources base="${catalina.base}/docroot/output" className="org.apache.catalina.webresources.DirResourceSet" webAppMount="/output" />
+        <PreResources base="${catalina.base}/../docroot/output" className="org.apache.catalina.webresources.DirResourceSet" webAppMount="/output" />
     </Resources>
 </Context>


### PR DESCRIPTION
Issue: #11 

Adding docker-compose deployment option with instructions in README. It will require the user having Docker and Docker-compose installed on their machines.

The benefit of this deployment is that it is consistent across all machines and will not require the user to download an application server.

When making the appropriate changes, I ensured that changes will not conflict with deployment settings of other app-servers. Everything I have added will only affect Tomcat deployment. More details can be found in the initial commit message and the README.