### PR TITLE
Rename incoming files by uuid to prevent rejection edge cases (#64)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>buildvu-microservice-example</artifactId>
     <packaging>war</packaging>
-    <version>8.0.2</version>
+    <version>9.0.0</version>
     <name>BuildVu Microservice Example</name>
 
     <dependencies>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.idrsolutions</groupId>
             <artifactId>base-microservice-example</artifactId>
-            <version>12.0.2</version>
+            <version>13.0.0</version>
         </dependency>
         <dependency>
             <groupId>buildvu</groupId>


### PR DESCRIPTION
Update base-microservice-example dependency to 13.0.0. Updates file storage strategy to name files by the uuid of the conversion rather than using their original filename. This prevents edge cases where certain filenames would otherwise need to be rejected. Increment major version number.